### PR TITLE
Consul-based job locks

### DIFF
--- a/bootique-job-consul/pom.xml
+++ b/bootique-job-consul/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>bootique-job-parent</artifactId>
+        <groupId>io.bootique.job</groupId>
+        <version>0.26-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>bootique-job-consul</artifactId>
+    <name>bootique-job-consul: Consul integration for Bootique Job</name>
+    <description>Provides the means to use Consul for locking job instances</description>
+
+    <properties>
+        <consul-client-version>1.2.0</consul-client-version>
+    </properties>
+
+    <dependencies>
+        <!-- project dependencies -->
+        <dependency>
+            <groupId>io.bootique.job</groupId>
+            <artifactId>bootique-job</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- 3-rd party dependencies -->
+        <dependency>
+            <groupId>com.orbitz.consul</groupId>
+            <artifactId>consul-client</artifactId>
+            <version>${consul-client-version}</version>
+        </dependency>
+
+        <!-- Unit test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.bootique</groupId>
+            <artifactId>bootique-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>bintray</name>
+            <url>http://jcenter.bintray.com</url>
+        </repository>
+    </repositories>
+
+</project>

--- a/bootique-job-consul/src/main/java/io/bootique/job/consul/ConsulJobConfig.java
+++ b/bootique-job-consul/src/main/java/io/bootique/job/consul/ConsulJobConfig.java
@@ -1,0 +1,54 @@
+package io.bootique.job.consul;
+
+import io.bootique.annotation.BQConfig;
+import io.bootique.annotation.BQConfigProperty;
+
+@BQConfig("Consul jobs configuration")
+public class ConsulJobConfig {
+
+    private String consulHost;
+    private Integer consulPort;
+    private String dataCenter;
+    private String serviceGroup;
+
+    public ConsulJobConfig() {
+        this.consulHost = "localhost";
+        this.consulPort = 8500;
+    }
+
+    @BQConfigProperty
+    public void setConsulHost(String consulHost) {
+        this.consulHost = consulHost;
+    }
+
+    @BQConfigProperty
+    public void setConsulPort(Integer consulPort) {
+        this.consulPort = consulPort;
+    }
+
+    @BQConfigProperty
+    public void setDataCenter(String dataCenter) {
+        this.dataCenter = dataCenter;
+    }
+
+    @BQConfigProperty("Value to prepend to job lock names to distinguish them from other services that use Consul")
+    public void setServiceGroup(String serviceGroup) {
+        this.serviceGroup = serviceGroup;
+    }
+
+    public String getConsulHost() {
+        return consulHost;
+    }
+
+    public Integer getConsulPort() {
+        return consulPort;
+    }
+
+    public String getDataCenter() {
+        return dataCenter;
+    }
+
+    public String getServiceGroup() {
+        return serviceGroup;
+    }
+}

--- a/bootique-job-consul/src/main/java/io/bootique/job/consul/ConsulJobModule.java
+++ b/bootique-job-consul/src/main/java/io/bootique/job/consul/ConsulJobModule.java
@@ -1,0 +1,43 @@
+package io.bootique.job.consul;
+
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import io.bootique.ConfigModule;
+import io.bootique.config.ConfigurationFactory;
+import io.bootique.job.consul.lock.ConsulLockHandlerProvider;
+import io.bootique.job.lock.LockHandler;
+import io.bootique.shutdown.ShutdownManager;
+
+@SuppressWarnings("unused")
+public class ConsulJobModule extends ConfigModule {
+
+    public ConsulJobModule() {
+    }
+
+    public ConsulJobModule(String configPrefix) {
+        super(configPrefix);
+    }
+
+    @Override
+    protected String defaultConfigPrefix() {
+        return "job-consul";
+    }
+
+    @Override
+    public void configure(Binder binder) {
+        binder.bind(Key.get(LockHandler.class)).toProvider(ConsulLockHandlerProvider.class);
+    }
+
+    @Provides
+    @Singleton
+    public ConsulLockHandlerProvider provideConsulLockHandlerProvider(
+            ConfigurationFactory configFactory, ShutdownManager shutdownManager) {
+
+        ConsulJobConfig config = configFactory.config(ConsulJobConfig.class, configPrefix);
+
+        return new ConsulLockHandlerProvider(config.getConsulHost(), config.getConsulPort(), config.getDataCenter(),
+                config.getServiceGroup(), shutdownManager);
+    }
+}

--- a/bootique-job-consul/src/main/java/io/bootique/job/consul/ConsulJobModuleProvider.java
+++ b/bootique-job-consul/src/main/java/io/bootique/job/consul/ConsulJobModuleProvider.java
@@ -1,0 +1,21 @@
+package io.bootique.job.consul;
+
+import com.google.inject.Module;
+import io.bootique.BQModuleProvider;
+import io.bootique.job.runtime.JobModule;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class ConsulJobModuleProvider implements BQModuleProvider {
+
+    @Override
+    public Module module() {
+        return new ConsulJobModule();
+    }
+
+    @Override
+    public Collection<Class<? extends Module>> overrides() {
+        return Collections.singleton(JobModule.class);
+    }
+}

--- a/bootique-job-consul/src/main/java/io/bootique/job/consul/ConsulSession.java
+++ b/bootique-job-consul/src/main/java/io/bootique/job/consul/ConsulSession.java
@@ -1,0 +1,57 @@
+package io.bootique.job.consul;
+
+import com.orbitz.consul.SessionClient;
+import com.orbitz.consul.model.session.ImmutableSession;
+import com.orbitz.consul.model.session.Session;
+import com.orbitz.consul.model.session.SessionCreatedResponse;
+
+import java.util.Optional;
+
+public class ConsulSession {
+
+    private final SessionClient sessionClient;
+    private final Optional<String> dataCenter;
+
+    private volatile String session;
+    private final Object lock;
+
+    public ConsulSession(SessionClient sessionClient) {
+        this(sessionClient, null);
+    }
+
+    public ConsulSession(SessionClient sessionClient, String dataCenter) {
+        this.sessionClient = sessionClient;
+        this.dataCenter = Optional.ofNullable(dataCenter);
+        this.lock = new Object();
+    }
+
+    public String getOrCreateSession() {
+        if (session == null) {
+            synchronized (lock) {
+                if (session == null) {
+                    session = createSession();
+                }
+            }
+        }
+        return session;
+    }
+
+    private String createSession() {
+        SessionCreatedResponse response = dataCenter
+                // create session in a specific DC, if present
+                .map(dc -> sessionClient.createSession(newSession(), dc))
+                .orElseGet(() -> sessionClient.createSession(newSession()));
+        return response.getId();
+    }
+
+    private Session newSession() {
+        return ImmutableSession.builder().build();
+    }
+
+    public void destroySessionIfPresent() {
+        String session = this.session;
+        if (session != null) {
+            sessionClient.destroySession(session);
+        }
+    }
+}

--- a/bootique-job-consul/src/main/java/io/bootique/job/consul/lock/ConsulLockHandler.java
+++ b/bootique-job-consul/src/main/java/io/bootique/job/consul/lock/ConsulLockHandler.java
@@ -1,0 +1,57 @@
+package io.bootique.job.consul.lock;
+
+import com.orbitz.consul.KeyValueClient;
+import io.bootique.job.JobMetadata;
+import io.bootique.job.lock.LockHandler;
+import io.bootique.job.runnable.JobOutcome;
+import io.bootique.job.runnable.JobResult;
+import io.bootique.job.runnable.RunnableJob;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Supplier;
+
+public class ConsulLockHandler implements LockHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsulLockHandler.class);
+
+    private final KeyValueClient kvClient;
+    private final Supplier<String> consulSessionSupplier;
+    private final String serviceGroup;
+
+    public ConsulLockHandler(KeyValueClient kvClient, Supplier<String> consulSessionSupplier, String serviceGroup) {
+        this.kvClient = kvClient;
+        this.consulSessionSupplier = consulSessionSupplier;
+        this.serviceGroup = serviceGroup;
+    }
+
+    @Override
+    public RunnableJob lockingJob(RunnableJob executable, JobMetadata metadata) {
+        return () -> {
+            String lockName = getLockName(metadata);
+
+            String sessionId = consulSessionSupplier.get();
+
+            LOGGER.info("Attempting to lock '{}'", lockName);
+            boolean acquired = kvClient.acquireLock(lockName, sessionId);
+            if (!acquired) {
+                LOGGER.info("** Another job instance owns the lock. Skipping execution of '{}'", lockName);
+                return new JobResult(metadata, JobOutcome.SKIPPED, null,
+                        "Another job instance owns the lock. Skipping execution");
+            }
+
+            try {
+                return executable.run();
+            } finally {
+                if (!kvClient.releaseLock(lockName, consulSessionSupplier.get())) {
+                    LOGGER.error("Failed to release lock, manual intervention might be needed: " + lockName);
+                }
+            }
+        };
+    }
+
+    private String getLockName(JobMetadata metadata) {
+        String jobName = metadata.getName();
+        return (serviceGroup == null || serviceGroup.isEmpty()) ?
+                jobName : (serviceGroup + "/" + jobName);
+    }
+}

--- a/bootique-job-consul/src/main/java/io/bootique/job/consul/lock/ConsulLockHandlerProvider.java
+++ b/bootique-job-consul/src/main/java/io/bootique/job/consul/lock/ConsulLockHandlerProvider.java
@@ -1,0 +1,35 @@
+package io.bootique.job.consul.lock;
+
+import com.google.common.net.HostAndPort;
+import com.google.inject.Provider;
+import com.orbitz.consul.Consul;
+import io.bootique.job.consul.ConsulSession;
+import io.bootique.job.lock.LockHandler;
+import io.bootique.shutdown.ShutdownManager;
+
+public class ConsulLockHandlerProvider implements Provider<LockHandler> {
+
+    private final String host;
+    private final int port;
+    private final String dataCenter;
+    private final String serviceGroup;
+    private final ShutdownManager shutdownManager;
+
+    public ConsulLockHandlerProvider(String host, int port, String dataCenter,
+                                     String serviceGroup, ShutdownManager shutdownManager) {
+        this.host = host;
+        this.port = port;
+        this.dataCenter = dataCenter;
+        this.serviceGroup = serviceGroup;
+        this.shutdownManager = shutdownManager;
+    }
+
+    @Override
+    public LockHandler get() {
+        HostAndPort hostAndPort = HostAndPort.fromParts(host, port);
+        Consul consul = Consul.builder().withHostAndPort(hostAndPort).build();
+        ConsulSession session = new ConsulSession(consul.sessionClient(), dataCenter);
+        shutdownManager.addShutdownHook(session::destroySessionIfPresent);
+        return new ConsulLockHandler(consul.keyValueClient(), session::getOrCreateSession, serviceGroup);
+    }
+}

--- a/bootique-job-consul/src/main/resources/META-INF/services/io.bootique.BQModuleProvider
+++ b/bootique-job-consul/src/main/resources/META-INF/services/io.bootique.BQModuleProvider
@@ -1,0 +1,1 @@
+io.bootique.job.consul.ConsulJobModuleProvider

--- a/bootique-job-consul/src/test/java/io/bootique/job/consul/ConsulJobModuleProviderTest.java
+++ b/bootique-job-consul/src/test/java/io/bootique/job/consul/ConsulJobModuleProviderTest.java
@@ -1,0 +1,12 @@
+package io.bootique.job.consul;
+
+import io.bootique.test.junit.BQModuleProviderChecker;
+import org.junit.Test;
+
+public class ConsulJobModuleProviderTest {
+	
+	@Test
+	public void testAutoLoadable() {
+		BQModuleProviderChecker.testAutoLoadable(ConsulJobModuleProvider.class);
+	}
+}

--- a/bootique-job-zookeeper/pom.xml
+++ b/bootique-job-zookeeper/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>bootique-job-parent</artifactId>
+        <groupId>io.bootique.job</groupId>
+        <version>0.26-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>bootique-job-zookeeper</artifactId>
+    <name>bootique-job-zookeeper: Zookeeper integration for Bootique Job</name>
+    <description>Provides the means to use Zookeeper for locking job instances</description>
+
+    <dependencies>
+        <!-- project dependencies -->
+        <dependency>
+            <groupId>io.bootique.job</groupId>
+            <artifactId>bootique-job</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.bootique.curator</groupId>
+            <artifactId>bootique-curator</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Unit test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.bootique</groupId>
+            <artifactId>bootique-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/bootique-job-zookeeper/src/main/java/io/bootique/job/zookeeper/ZkJobModule.java
+++ b/bootique-job-zookeeper/src/main/java/io/bootique/job/zookeeper/ZkJobModule.java
@@ -1,0 +1,30 @@
+package io.bootique.job.zookeeper;
+
+import com.google.inject.Injector;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import io.bootique.ConfigModule;
+import io.bootique.job.lock.LockHandler;
+import io.bootique.job.zookeeper.lock.ZkClusterLockHandler;
+
+@SuppressWarnings("unused")
+public class ZkJobModule extends ConfigModule {
+
+    public ZkJobModule() {
+    }
+
+    public ZkJobModule(String configPrefix) {
+        super(configPrefix);
+    }
+
+    @Override
+    protected String defaultConfigPrefix() {
+        return "job-consul";
+    }
+
+    @Provides
+    @Singleton
+    LockHandler provideClusteredLockHandler(Injector injector) {
+        return new ZkClusterLockHandler(injector);
+    }
+}

--- a/bootique-job-zookeeper/src/main/java/io/bootique/job/zookeeper/ZkJobModuleProvider.java
+++ b/bootique-job-zookeeper/src/main/java/io/bootique/job/zookeeper/ZkJobModuleProvider.java
@@ -1,0 +1,21 @@
+package io.bootique.job.zookeeper;
+
+import com.google.inject.Module;
+import io.bootique.BQModuleProvider;
+import io.bootique.job.runtime.JobModule;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class ZkJobModuleProvider implements BQModuleProvider {
+
+    @Override
+    public Module module() {
+        return new ZkJobModule();
+    }
+
+    @Override
+    public Collection<Class<? extends Module>> overrides() {
+        return Collections.singleton(JobModule.class);
+    }
+}

--- a/bootique-job-zookeeper/src/main/java/io/bootique/job/zookeeper/lock/ZkClusterLockHandler.java
+++ b/bootique-job-zookeeper/src/main/java/io/bootique/job/zookeeper/lock/ZkClusterLockHandler.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package io.bootique.job.lock.zookeeper;
+package io.bootique.job.zookeeper.lock;
 
 import io.bootique.job.JobMetadata;
 import io.bootique.job.runnable.JobOutcome;

--- a/bootique-job-zookeeper/src/main/java/io/bootique/job/zookeeper/lock/ZkMutex.java
+++ b/bootique-job-zookeeper/src/main/java/io/bootique/job/zookeeper/lock/ZkMutex.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package io.bootique.job.lock.zookeeper;
+package io.bootique.job.zookeeper.lock;
 
 import java.util.concurrent.TimeUnit;
 

--- a/bootique-job-zookeeper/src/main/resources/META-INF/services/io.bootique.BQModuleProvider
+++ b/bootique-job-zookeeper/src/main/resources/META-INF/services/io.bootique.BQModuleProvider
@@ -1,0 +1,1 @@
+io.bootique.job.zookeeper.ZkJobModuleProvider

--- a/bootique-job-zookeeper/src/test/java/io/bootique/job/zookeeper/ConsulJobModuleProviderTest.java
+++ b/bootique-job-zookeeper/src/test/java/io/bootique/job/zookeeper/ConsulJobModuleProviderTest.java
@@ -1,0 +1,12 @@
+package io.bootique.job.zookeeper;
+
+import io.bootique.test.junit.BQModuleProviderChecker;
+import org.junit.Test;
+
+public class ConsulJobModuleProviderTest {
+	
+	@Test
+	public void testAutoLoadable() {
+		BQModuleProviderChecker.testAutoLoadable(ZkJobModuleProvider.class);
+	}
+}

--- a/bootique-job/src/main/java/io/bootique/job/runtime/JobModuleExtender.java
+++ b/bootique-job/src/main/java/io/bootique/job/runtime/JobModuleExtender.java
@@ -129,5 +129,4 @@ public class JobModuleExtender {
         }
         return mappedListeners;
     }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
     <modules>
         <module>bootique-job</module>
         <module>bootique-job-instrumented</module>
+        <module>bootique-job-consul</module>
+        <module>bootique-job-zookeeper</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
@andrus , this is a module that provides Consul-based clustered locks. It works fine, but is very limited wrt Consul configuration. Could you tell me, if this is something that you'd like to see in bootique-job, and if the current bare bones configuration is OK for now, or you'd prefer to have a dedicated Consul integration module right from the start (again, if it's something that might be welcome in Bootique?) Thanks in advance for your response!