### PR TITLE
feat: add ability to set custom lock name for the set of parameters o…

### DIFF
--- a/bootique-job/src/main/java/io/bootique/job/JobMetadata.java
+++ b/bootique-job/src/main/java/io/bootique/job/JobMetadata.java
@@ -23,8 +23,10 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.UUID;
 
 public class JobMetadata {
+    private static final String LOCK_NAME_KEY = "LOCK-NAME-KEY-" + UUID.randomUUID();
 
     private String name;
     private Collection<JobParameterMetadata<?>> parameters;
@@ -84,6 +86,15 @@ public class JobMetadata {
         return parameters != null ? parameters : Collections.emptyList();
     }
 
+    public String getLockName() {
+        return parameters.stream()
+                .filter(jobParameterMetadata -> jobParameterMetadata.getName().equals(LOCK_NAME_KEY))
+                .findAny()
+                .map(JobParameterMetadata::getDefaultValue)
+                .map(Object::toString)
+                .orElse(name);
+    }
+
     public static class Builder {
 
         private String name;
@@ -129,6 +140,10 @@ public class JobMetadata {
 
         public Builder longParam(String name, Long longValue) {
             return param(new LongParameter(name, longValue));
+        }
+
+        public Builder lockName(String lockName) {
+            return param(new StringParameter(LOCK_NAME_KEY, lockName));
         }
 
         public JobMetadata build() {

--- a/bootique-job/src/main/java/io/bootique/job/lock/LocalLockHandler.java
+++ b/bootique-job/src/main/java/io/bootique/job/lock/LocalLockHandler.java
@@ -47,7 +47,6 @@ public class LocalLockHandler implements LockHandler {
 
 	@Override
 	public RunnableJob lockingJob(RunnableJob executable, JobMetadata metadata) {
-
 		return () -> {
 			String lockName = toLockName(metadata);
 			Lock lock = getLock(lockName);
@@ -73,6 +72,6 @@ public class LocalLockHandler implements LockHandler {
 	}
 
 	private String toLockName(JobMetadata metadata) {
-		return metadata.getName();
+		return metadata.getLockName();
 	}
 }


### PR DESCRIPTION
#84 
- Metadata provides lock name, which will be equals to job name by default
- Metadata Builder provides ability to set custom lock name, which will be saved in parameters with generated key